### PR TITLE
Compose in run

### DIFF
--- a/lib/optika.js
+++ b/lib/optika.js
@@ -99,9 +99,12 @@ function arraySingleton(x) {
   return [x];
 }
 
-function Optic(classes, run) {
+function Optic(classes, parts) {
+  u.assert(u.isString(classes), "new Optic: classes should be string");
+  u.assert(u.isArray(parts), "new Optic: parts should be an array");
+
   this.classes = classes;
-  this.unsafeRun = run;
+  this.parts = parts;
 }
 
 /**
@@ -207,9 +210,9 @@ function lens(getter, setter) {
     return [getter(s), function (b) { return setter(s, b); }];
   }
 
-  return new Optic("strong", function (p) {
+  return new Optic("strong", [function (p) {
     return p.first().dimap(getter2, lensSetter);
-  });
+  }]);
 }
 
 /**
@@ -218,18 +221,18 @@ function lens(getter, setter) {
     Creates traversal for everything with `.map` and `.forEach`.
 */
 function traversed() {
-  return new Optic("wander", function (p) {
+  return new Optic("wander", [function (p) {
     return p.wander();
-  });
+  }]);
 }
 
 /**
   - `to(f: S => A): Getter<S,A>`
 */
 function to(f) {
-  return new Optic("bicontra", function (p) {
+  return new Optic("bicontra", [function (p) {
     return p.cimap(f, f);
-  });
+  }]);
 }
 
 /**
@@ -288,9 +291,9 @@ function filtered(pred) {
     return [pred(x), x];
   }
 
-  return new Optic("choice", function (p) {
+  return new Optic("choice", [function (p) {
     return p.right().dimap(filteredGetter, u.snd);
-  });
+  }]);
 }
 
 /**
@@ -312,9 +315,9 @@ function safeFiltered(pred) {
     return x;
   }
 
-  return new Optic("choice", function (p) {
+  return new Optic("choice", [function (p) {
     return p.dimap(u.identity, check).right().dimap(filteredGetter, u.snd);
-  });
+  }]);
 }
 
 /**
@@ -332,10 +335,7 @@ Optic.prototype.o = function o(other) {
   var self = this;
   var classes = profunctor.normaliseClasses(self.classes, other.classes);
 
-  // TODO: optimise to compose in `_run`.
-  return new Optic(classes, function (p) {
-    return self.unsafeRun(other.unsafeRun(p));
-  });
+  return new Optic(classes, other.parts.concat(this.parts));
 };
 
 /**
@@ -352,7 +352,12 @@ Optic.prototype.run = function (p) {
       profunctor.classesToOpticName(thisClasses),
     ].join(" ");
   });
-  return this.unsafeRun(p);
+
+  var parts = this.parts;
+  for (var i = 0; i < parts.length; i++) {
+    p = parts[i](p);
+  }
+  return p;
 };
 
 // Exports

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,10 @@ function isFunction(f) {
   return typeof f === "function";
 }
 
+function isArray(a) {
+  return Array.isArray(a);
+}
+
 function assert(cond, msg) {
   if (!cond) {
     if (isFunction(msg)) {
@@ -37,11 +41,11 @@ function snd(p) {
 }
 
 module.exports = {
-  identity: identity,
-  isString: isString,
-  // fst: fst,
-  snd: snd,
-  isFunction: isFunction,
   assert: assert,
   hasOwn: hasOwn,
+  identity: identity,
+  isArray: isArray,
+  isFunction: isFunction,
+  isString: isString,
+  snd: snd,
 };


### PR DESCRIPTION
In comparison with partial.lenses:

```
Was: 8,549/s    10.31x  K.traversed().traversed().traversed().arrayOf(xsss100)
Now: 16,075/s    3.82x  K.traversed().traversed().traversed().arrayOf(xsss100)
```