### PR TITLE
readme: add backtick to fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ o.key("foo").to(function (x) { return x[0]; }).set(value, 42);
 
   Construct value thru `Prism` or `Iso`.
 
-- `affineView(this: Affine<S,T,A,B>, def: A): A
+- `affineView(this: Affine<S,T,A,B>, def: A): A`
 
   For operation working with `Fold`, see `firstOf`.
 


### PR DESCRIPTION
This PR adds a backtick to the type signature of `affineView` to prettify the formatting.

Cheers