### PR TITLE
readme: fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ o.key("foo").to(function (x) { return x[0]; }).set(value, 42);
 
   Construct value thru `Prism` or `Iso`.
 
-- `affineView(this: Affine<S,T,A,B>, def: A): A
+- `affineView(this: Affine<S,T,A,B>, def: A): A`
 
   For operation working with `Fold`, see `firstOf`.
 
@@ -186,7 +186,6 @@ Compose two optics.
 - [partial.lenses](https://github.com/calmm-js/partial.lenses)
 - [ramda-lens](https://github.com/ramda/ramda-lens)
 - [flunc-optics](https://github.com/flunc/optics)
-- [monocle-ts](https://github.com/gcanti/monocle-ts)
 
 The MIT License (MIT)
 

--- a/lib/optika.js
+++ b/lib/optika.js
@@ -145,7 +145,7 @@ Optic.prototype.review = function (value) {
 };
 
 /**
-  - `affineView(this: Affine<S,T,A,B>, def: A): A
+  - `affineView(this: Affine<S,T,A,B>, def: A): A`
 
     For operation working with `Fold`, see `firstOf`.
 */


### PR DESCRIPTION
This PR is a redo of #14 where I actually change the correct file (`lib/optika.js`), and autogenerate the README.

What’s a bit funky is that there is another change that wasn’t yet present in the README (the related work part is now missing the link to `monocle-ts`), but that seems to be correct. If it isn’t, I can of course also add it to `related-work.md` and rebuild the README.

Cheers